### PR TITLE
feat: stub media query for loading custom dark styles by page

### DIFF
--- a/cypress/fixtures/custom-dark.html
+++ b/cypress/fixtures/custom-dark.html
@@ -1,0 +1,19 @@
+<body>
+
+  <head>
+    <link rel="stylesheet" href="normal.css">
+    <script>
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        const link = document.createElement("link")
+        link.type = "text/css";
+        link.rel = "stylesheet";
+        link.href = 'dark.css';
+        document.head.appendChild(link)
+      }
+    </script>
+  </head>
+
+  <body>
+    <p>Custom dark theme on this page</p>
+  </body>
+</body>

--- a/cypress/fixtures/dark.css
+++ b/cypress/fixtures/dark.css
@@ -1,0 +1,5 @@
+/* https://paulmillr.com/posts/using-dark-mode-in-css/ */
+body {
+  color: #ddd !important;
+  background-color: #222 !important;
+}

--- a/cypress/fixtures/normal.css
+++ b/cypress/fixtures/normal.css
@@ -1,0 +1,6 @@
+body {
+  background-color: #ddd;
+  color: #333;
+  padding: 50px;
+  font-size: 200%;
+}

--- a/cypress/integration/custom-dark-spec.js
+++ b/cypress/integration/custom-dark-spec.js
@@ -1,0 +1,12 @@
+require('../../src')
+
+describe('custom dark theme', () => {
+  it('loads page with dark theme', () => {
+    cy.visit('cypress/fixtures/custom-dark.html')
+    cy
+      .get('body')
+      .should('have.css', 'color', 'rgb(221, 221, 221)')
+      .and('have.css', 'background-color', 'rgb(34, 34, 34)')
+    cy.get('@dark-media-query').should('have.been.calledOnce')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,7 +1337,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -5148,7 +5148,7 @@
     },
     "inquirer-confirm": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer-confirm/-/inquirer-confirm-0.2.2.tgz",
       "integrity": "sha1-b0BtA3v52eRV7w+VOSnzV/6aiEg=",
       "dev": true,
       "requires": {
@@ -11188,7 +11188,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
@@ -12601,7 +12601,7 @@
         },
         "table": {
           "version": "4.0.3",
-          "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
           "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
           "dev": true,
           "requires": {

--- a/src/halloween.js
+++ b/src/halloween.js
@@ -1,10 +1,16 @@
 /// <reference types="cypress" />
 const { join } = require('path')
-const { getSourceFolder, hasFailed, loadTheme } = require('./utils')
+const {
+  getSourceFolder,
+  hasFailed,
+  loadTheme,
+  stubMediaQuery
+} = require('./utils')
 
 /* eslint-env mocha, browser */
 /* global cy */
 before(loadTheme('halloween'))
+before(stubMediaQuery())
 
 const witchLaughs = () => {
   const filename = join(getSourceFolder(), 'halloween-laugh.mp3')

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-const { loadTheme } = require('./utils')
+const { loadTheme, stubMediaQuery } = require('./utils')
 
 /* eslint-env mocha, browser */
 before(loadTheme())
+before(stubMediaQuery())

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,9 +86,27 @@ const loadTheme = theme => {
   }
 }
 
+const stubMediaQuery = () => () => {
+  // if website supports loading dark theme styles via JavaScript
+  // then tell it to. Website should ask like this
+  // if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  //  load dark css
+  // }
+  Cypress.on('window:before:load', win => {
+    cy
+      .stub(win, 'matchMedia')
+      .withArgs('(prefers-color-scheme: dark)')
+      .returns({
+        matches: true
+      })
+      .as('dark-media-query')
+  })
+}
+
 module.exports = {
   getSourceFolder,
   hasFailed,
   loadTheme,
-  isTheme
+  isTheme,
+  stubMediaQuery
 }


### PR DESCRIPTION
- close #29 

See the `cypress/fixtures/custom-dark.html` example page.

<img width="967" alt="screen shot 2018-10-25 at 12 13 06 pm" src="https://user-images.githubusercontent.com/2212006/47493468-a1996200-d84f-11e8-8fc4-81c957849105.png">
