### PR TITLE
fix: Issue with cypress 3.4.0 version

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ const getSourceFolder = () => {
   const sourceFolder = installedAsFile
     ? join('node_modules/cypress-dark/src')
     : __dirname
-  return sourceFolder
+  return sourceFolder.replace(/^\//, '')
 }
 
 /**
@@ -77,8 +77,7 @@ const loadTheme = theme => {
 
     const themeFilename = join(getSourceFolder(), `${theme}.css`)
 
-    cy
-      .readFile(themeFilename, { log: false })
+    cy.readFile(themeFilename, { log: false })
       .then(convertCssVariables)
       .then(css => {
         $head.append(
@@ -99,8 +98,7 @@ const stubMediaQuery = () => () => {
   //  load dark css
   // }
   Cypress.on('window:before:load', win => {
-    cy
-      .stub(win, 'matchMedia')
+    cy.stub(win, 'matchMedia')
       .withArgs('(prefers-color-scheme: dark)')
       .returns({
         matches: true


### PR DESCRIPTION
This PR solves an issue with this plugin when you try to install it for cypress versions newer than 3.2.0 and it is related to this Issue https://github.com/cypress-io/cypress/issues/4352

![Screen Shot 2019-08-21 at 12 11 23](https://user-images.githubusercontent.com/12685053/63423556-d55ffc80-c40c-11e9-9b03-e487aaad0494.png)

# How to reproduce

Install the latest version of cypress and try to run cypress dark it will give you the screenshot error.

# This PR solution

I added this line to replace the first slash so that this will work on the latest cypress version as well it works on the oldest ones. 

![Screen Shot 2019-08-21 at 12 13 09](https://user-images.githubusercontent.com/12685053/63423647-0dffd600-c40d-11e9-802e-fe2fbbd44f0a.png)

This slash gives problems since version 3.3.1 as this comment says https://github.com/cypress-io/cypress/issues/4352#issuecomment-497663506
